### PR TITLE
Fixing coverage upload to sonar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
 		<jline.version>3.21.0</jline.version>
 		<sonar.organization>mastercard</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
-		<sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/aggregator/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
The sonar logs at least show reports being imported now, but time will tell if those will show up in the sonar interface...