### PR TITLE
Correcting code markup

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -58,7 +58,7 @@ graph TD
 
 <details>
 <summary>Artifact dependency structure</summary>
-Solid lines are `compile`-scope dependencies, dotted are `test`-scope.
+    Solid lines are <code>compile</code>-scope dependencies, dotted are <code>test</code>-scope.
 
 <!-- start_module_diagram:example -->
 


### PR DESCRIPTION
Apparently we can't use markdown inside a `<details>` element