### PR TITLE
Fixed logging

### DIFF
--- a/example/app-assert/src/main/java/com/mastercard/test/flow/example/app/assrt/AbstractServiceTest.java
+++ b/example/app-assert/src/main/java/com/mastercard/test/flow/example/app/assrt/AbstractServiceTest.java
@@ -8,10 +8,12 @@ import static com.mastercard.test.flow.example.app.model.ExampleSystem.Unpredict
 
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.TestFactory;
@@ -75,6 +77,18 @@ public abstract class AbstractServiceTest {
 	@AfterAll
 	public static void stopDependencies() {
 		dependencyInstance.stop();
+	}
+
+	/**
+	 * It's pretty easy to create a dependency version mismatch between slf4j and
+	 * slf4j-simple that breaks logging behaviour. The end result of this is fairly
+	 * subtle - no logs appear in the execution reports. This test will assert that
+	 * the log file is being created as expected.
+	 */
+	@AfterAll
+	static void checkLogs() {
+		Assertions.assertTrue( Files.exists( Util.LOG_FILE_PATH ),
+				"logging behaviour broken!" );
 	}
 
 	/**

--- a/example/app-assert/src/main/java/com/mastercard/test/flow/example/app/assrt/Util.java
+++ b/example/app-assert/src/main/java/com/mastercard/test/flow/example/app/assrt/Util.java
@@ -1,5 +1,6 @@
 package com.mastercard.test.flow.example.app.assrt;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import com.mastercard.test.flow.assrt.log.Tail;
@@ -9,6 +10,11 @@ import com.mastercard.test.flow.assrt.log.Tail;
  */
 public class Util {
 
+	/**
+	 * The log file location
+	 */
+	public static final Path LOG_FILE_PATH = Paths.get( "target/test_log.txt" );
+
 	private Util() {
 		// no instances
 	}
@@ -17,8 +23,7 @@ public class Util {
 	 * Extracts content from the log format produced by
 	 * src/main/resources/simplelogger.properties
 	 */
-	public static final Tail LOG_CAPTURE = new Tail(
-			Paths.get( "target/test_log.txt" ),
+	public static final Tail LOG_CAPTURE = new Tail( LOG_FILE_PATH,
 			"(?<time>\\S+) \\[[^\\]]+\\] (?<level>[A-Z]+) (?<source>\\S+)" );
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,20 @@
 				<version>4.12</version>
 			</dependency>
 
+			<dependency>
+				<!-- REST framework -->
+				<groupId>com.sparkjava</groupId>
+				<artifactId>spark-core</artifactId>
+				<version>2.9.4</version>
+			</dependency>
+
+			<dependency>
+				<!-- Logging support (version dictated by spark) -->
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-simple</artifactId>
+				<version>1.7.32</version>
+			</dependency>
+
 		</dependencies>
 	</dependencyManagement>
 

--- a/report/report-core/pom.xml
+++ b/report/report-core/pom.xml
@@ -61,7 +61,6 @@
 			<!-- REST framework, used to serve the report for testing -->
 			<groupId>com.sparkjava</groupId>
 			<artifactId>spark-core</artifactId>
-			<version>2.9.4</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -81,10 +80,9 @@
 		</dependency>
 
 		<dependency>
-			<!-- Logging support -->
+			<!-- Logging support - captures content from spark -->
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>2.0.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/report/report-core/src/test/java/com/mastercard/test/flow/report/index/ServedIndexTest.java
+++ b/report/report-core/src/test/java/com/mastercard/test/flow/report/index/ServedIndexTest.java
@@ -1,5 +1,11 @@
 package com.mastercard.test.flow.report.index;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.mastercard.test.flow.report.seq.Browser;
@@ -10,8 +16,28 @@ import com.mastercard.test.flow.report.seq.Browser;
 @ExtendWith(Browser.class)
 class ServedIndexTest extends AbstractIndexTest {
 
+	private static final Path LOG_FILE_PATH = Paths.get( "target/test_log.txt" );
+
 	/***/
 	ServedIndexTest() {
 		super( report.url() );
+	}
+
+	/**
+	 * Checks that the expected log file has been created
+	 * <p>
+	 * Spark logs some stuff on startup via slf4j. If an appropriate logger
+	 * implementation isn't available slf4j will complain on stdout. We don't like
+	 * that, so we've included the slf4j-simple implementation on the classpath to
+	 * keep slf4j happy. It's pretty easy to create a dependency version mismatch
+	 * that breaks that behaviour though, so this test will assert that the log file
+	 * is being created as expected, which implies that we're avoiding the stdout
+	 * noise that we don't want.
+	 * </p>
+	 */
+	@AfterAll
+	static void checkLogs() {
+		Assertions.assertTrue( Files.exists( LOG_FILE_PATH ),
+				"logging behaviour broken!" );
 	}
 }


### PR DESCRIPTION
#70 introduced a version mismatch that broke logging. This change rolls back that update and adds testing to catch again in the future.