### PR TITLE
Added autonomous actors

### DIFF
--- a/assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java
+++ b/assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java
@@ -4,6 +4,7 @@ package com.mastercard.test.flow.assrt;
 import static com.mastercard.test.flow.assrt.History.Result.NOT_OBSERVED;
 import static java.time.Instant.now;
 import static java.time.ZoneId.systemDefault;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 
@@ -238,8 +239,8 @@ public abstract class AbstractFlocessor<T extends AbstractFlocessor<T>> {
 		if( !systemUnderTest.containsAll( autonomous ) ) {
 			throw new IllegalArgumentException( String.format(
 					"Autonomous actors '%s' must be a subset of system '%s'",
-					autonomous.stream().map( Actor::name ).collect( Collectors.joining( "," ) ),
-					systemUnderTest.stream().map( Actor::name ).collect( Collectors.joining( "," ) ) ) );
+					autonomous.stream().map( Actor::name ).sorted().collect( joining( "," ) ),
+					systemUnderTest.stream().map( Actor::name ).sorted().collect( joining( "," ) ) ) );
 		}
 		return self();
 	}

--- a/assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java
+++ b/assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java
@@ -434,6 +434,7 @@ public abstract class AbstractFlocessor<T extends AbstractFlocessor<T>> {
 						"No interactions with system [%s], but autonomous actor '%s' is assumed to be doing something",
 						systemUnderTest.stream()
 								.map( Actor::name )
+								.sorted()
 								.collect( Collectors.joining( "," ) ),
 						flow.root().requester().name() ) );
 			}
@@ -442,6 +443,7 @@ public abstract class AbstractFlocessor<T extends AbstractFlocessor<T>> {
 						"No interactions with system [%s]",
 						systemUnderTest.stream()
 								.map( Actor::name )
+								.sorted()
 								.collect( Collectors.joining( "," ) ) ) );
 			}
 		}

--- a/assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/History.java
+++ b/assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/History.java
@@ -29,6 +29,11 @@ public class History {
 		 */
 		UNEXPECTED(true),
 		/**
+		 * We had an opportunity to process the {@link Flow}, but the root {@link Actor}
+		 * is autonomous so we could not observe results
+		 */
+		NOT_OBSERVED(true),
+		/**
 		 * An error occurred when the {@link Flow} was processed
 		 */
 		ERROR(false),
@@ -62,7 +67,7 @@ public class History {
 	 * @param result The outcome of processing that {@link Flow}
 	 */
 	public void recordResult( Flow flow, Result result ) {
-		results.put( flow, result );
+		results.putIfAbsent( flow, result );
 	}
 
 	/**

--- a/assert/assert-core/src/test/java/com/mastercard/test/flow/assrt/AutonomyTest.java
+++ b/assert/assert-core/src/test/java/com/mastercard/test/flow/assrt/AutonomyTest.java
@@ -2,6 +2,7 @@ package com.mastercard.test.flow.assrt;
 
 import static com.mastercard.test.flow.assrt.AbstractFlocessorTest.copypasta;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +25,7 @@ class AutonomyTest {
 	 * @param expect Expected test results
 	 */
 	private static void test( State state, Actor auton, String... expect ) {
-		TestFlocessor tf = new TestFlocessor( "baseline", TestModel.asynchronousTransfer() )
+		TestFlocessor tf = new TestFlocessor( "AutonomyTest", TestModel.asynchronousTransfer() )
 				.system( state, Actors.B, Actors.C )
 				.behaviour( assrt -> {
 					assrt.actual().response( assrt.expected().response().content() );
@@ -111,4 +112,18 @@ class AutonomyTest {
 				"third [] SUCCESS" );
 	}
 
+	/**
+	 * Autonomous actors must be part of the system under test
+	 */
+	@Test
+	void validation() {
+		TestFlocessor tf = new TestFlocessor( "validation", TestModel.asynchronousTransfer() )
+				.system( State.FUL, Actors.B, Actors.C );
+
+		IllegalArgumentException iae = assertThrows( IllegalArgumentException.class,
+				() -> tf.autonomous( Actors.D ) );
+
+		assertEquals( "Autonomous actors 'D' must be a subset of system 'B,C'",
+				iae.getMessage() );
+	}
 }

--- a/assert/assert-core/src/test/java/com/mastercard/test/flow/assrt/AutonomyTest.java
+++ b/assert/assert-core/src/test/java/com/mastercard/test/flow/assrt/AutonomyTest.java
@@ -1,0 +1,114 @@
+package com.mastercard.test.flow.assrt;
+
+import static com.mastercard.test.flow.assrt.AbstractFlocessorTest.copypasta;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.mastercard.test.flow.Actor;
+import com.mastercard.test.flow.assrt.AbstractFlocessor.State;
+import com.mastercard.test.flow.assrt.TestModel.Actors;
+
+/**
+ * Illustrates the effects of
+ * {@link AbstractFlocessor#autonomous(com.mastercard.test.flow.Actor...)}
+ */
+@SuppressWarnings("static-method")
+class AutonomyTest {
+
+	/**
+	 * Builds a flocessor then asserts on its results
+	 *
+	 * @param state  Whether the SUT is statefull or stateless
+	 * @param auton  The autonomous actor, or <code>null</code> if there are none
+	 * @param expect Expected test results
+	 */
+	private static void test( State state, Actor auton, String... expect ) {
+		TestFlocessor tf = new TestFlocessor( "baseline", TestModel.asynchronousTransfer() )
+				.system( state, Actors.B, Actors.C )
+				.behaviour( assrt -> {
+					assrt.actual().response( assrt.expected().response().content() );
+				} );
+		if( auton != null ) {
+			tf.autonomous( auton );
+		}
+
+		tf.execute();
+
+		assertEquals( copypasta( expect ),
+				copypasta( "events", tf.events(), "results", tf.results() ) );
+	}
+
+	/**
+	 * One of the flows happens entirely within the stateless system
+	 */
+	@Test
+	void stateless() {
+		test( State.LESS, null,
+				"events",
+				"COMPARE first []",
+				"com.mastercard.test.flow.assrt.TestModel.asynchronousTransfer(TestModel.java:_) A->B [] response",
+				" | OK, but not right now | OK, but not right now |",
+				"",
+				"SKIP No interactions with system [B,C]",
+				"COMPARE third []",
+				"com.mastercard.test.flow.assrt.TestModel.asynchronousTransfer(TestModel.java:_) A->C [] response",
+				" | Yep! Is 'this' it? | Yep! Is 'this' it? |",
+				"results",
+				"first [] SUCCESS",
+				// skipped due to interactions being internal to the SUT
+				"second [] SKIP",
+				// processed as the system is stateless so results of prerequisites can be
+				// ignored
+				"third [] SUCCESS" );
+	}
+
+	/**
+	 * One of the flows happens entirely within the stateful system
+	 */
+	@Test
+	void stateful() {
+		test( State.FUL, null,
+				"events",
+				"COMPARE first []",
+				"com.mastercard.test.flow.assrt.TestModel.asynchronousTransfer(TestModel.java:_) A->B [] response",
+				" | OK, but not right now | OK, but not right now |",
+				"",
+				"SKIP No interactions with system [B,C]",
+				"SKIP Missing dependency",
+				"results",
+				"first [] SUCCESS",
+				// skipped due to interactions being internal to the SUT
+				"second [] SKIP",
+				// skipped as prerequisite 'second' was skipped - we can't rely on the state
+				// that we expected it to leave behind
+				"third [] SKIP" );
+	}
+
+	/**
+	 * One of the flows happens entirely within the stateful system, but we've set
+	 * the expectation that one of the actors in the system is capable of taking
+	 * autonomous actions
+	 */
+	@Test
+	void autonomous() {
+		test( State.FUL, Actors.B,
+				"events",
+				"COMPARE first []",
+				"com.mastercard.test.flow.assrt.TestModel.asynchronousTransfer(TestModel.java:_) A->B [] response",
+				" | OK, but not right now | OK, but not right now |",
+				"",
+				"SKIP No interactions with system [B,C], but autonomous actor 'B' is assumed to be doing something",
+				"COMPARE third []",
+				"com.mastercard.test.flow.assrt.TestModel.asynchronousTransfer(TestModel.java:_) A->C [] response",
+				" | Yep! Is 'this' it? | Yep! Is 'this' it? |",
+				"results",
+				"first [] SUCCESS",
+				// skipped due to interactions being internal to the SUT
+				"second [] NOT_OBSERVED",
+				// Processed! The test is able to assume that autonomous actor B is doing what
+				// we expect
+				"third [] SUCCESS" );
+	}
+
+}

--- a/assert/assert-core/src/test/java/com/mastercard/test/flow/assrt/HistoryTest.java
+++ b/assert/assert-core/src/test/java/com/mastercard/test/flow/assrt/HistoryTest.java
@@ -50,23 +50,25 @@ class HistoryTest {
 				.meta( data -> data
 						.description( "child" ) ) );
 
-		History hst = new History();
-
 		Stream.of( null, Result.PENDING, Result.SUCCESS, Result.SKIP, Result.ERROR )
 				.forEach( r -> {
+					History hst = new History();
 					hst.recordResult( parent, r );
 					assertEquals( null, hst.skipReason( child, State.FUL, Collections.emptySet() )
 							.orElse( null ),
 							"basis " + r );
 				} );
 
-		hst.recordResult( parent, Result.UNEXPECTED );
-
-		assertEquals( "Ancestor failed", hst.skipReason( child, State.FUL, Collections.emptySet() )
-				.orElse( null ),
-				"basis failure" );
+		{
+			History hst = new History();
+			hst.recordResult( parent, Result.UNEXPECTED );
+			assertEquals( "Ancestor failed", hst.skipReason( child, State.FUL, Collections.emptySet() )
+					.orElse( null ),
+					"basis failure" );
+		}
 
 		try {
+			History hst = new History();
 			AssertionOptions.SUPPRESS_BASIS_CHECK.set( "true" );
 			assertEquals( null, hst.skipReason( child, State.FUL, Collections.emptySet() )
 					.orElse( null ),

--- a/assert/assert-core/src/test/java/com/mastercard/test/flow/assrt/TestModel.java
+++ b/assert/assert-core/src/test/java/com/mastercard/test/flow/assrt/TestModel.java
@@ -280,4 +280,43 @@ public class TestModel {
 
 		return new Mdl().withFlows( first, second, third );
 	}
+
+	/**
+	 * A model with three flows:
+	 * <ul>
+	 * <li>A to B</li>
+	 * <li>B to C</li>
+	 * <li>A to C</li>
+	 * </ul>
+	 *
+	 * @return A model with three flows
+	 */
+	public static Model asynchronousTransfer() {
+		Flow first = Creator.build( flow -> flow
+				.meta( data -> data
+						.description( "first" ) )
+				.call( a -> a.from( Actors.A ).to( Actors.B )
+						.request( new Text( "Give 'this' to C" ) )
+						.response( new Text( "OK, but not right now" ) ) ) );
+
+		Flow second = Creator
+				.build( flow -> flow
+						.meta( data -> data
+								.description( "second" ) )
+						.prerequisite( first )
+						.call( a -> a.from( Actors.B ).to( Actors.C )
+								.request( new Text( "Hi! 'this' is from A" ) )
+								.response( new Text( "OK thanks!" ) ) ) );
+
+		Flow third = Creator
+				.build( flow -> flow
+						.meta( data -> data
+								.description( "third" ) )
+						.prerequisite( second )
+						.call( a -> a.from( Actors.A ).to( Actors.C )
+								.request( new Text( "Did B give you anything?" ) )
+								.response( new Text( "Yep! Is 'this' it?" ) ) ) );
+
+		return new Mdl().withFlows( first, second, third );
+	}
 }

--- a/doc/src/main/markdown/further.md
+++ b/doc/src/main/markdown/further.md
@@ -13,7 +13,7 @@ By default the report will be saved to a timestamped directory under `target/mct
 
 <!-- code_link_start -->
 
-[AbstractFlocessor.reporting(Reporting)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L189-L196,189-196
+[AbstractFlocessor.reporting(Reporting)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L190-L197,190-197
 [Reporting]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/Reporting.java
 
 <!-- code_link_end -->
@@ -78,8 +78,8 @@ Note that only the tag/index-based filtering can be used to avoid flow construct
 
 <!-- code_link_start -->
 
-[AbstractFlocessor.filtering(Consumer)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L305-L313,305-313
-[AbstractFlocessor.exercising(Predicate,Consumer)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L318-L343,318-343
+[AbstractFlocessor.filtering(Consumer)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L306-L314,306-314
+[AbstractFlocessor.exercising(Predicate,Consumer)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L319-L344,319-344
 
 <!-- code_link_end -->
 
@@ -123,7 +123,7 @@ Note that the assertion components will not make any assumptions about the forma
 [LogCapture]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/LogCapture.java
 [Tail]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/log/Tail.java
 [Merge]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/log/Merge.java
-[AbstractFlocessor.logs(LogCapture)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L273-L280,273-280
+[AbstractFlocessor.logs(LogCapture)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L274-L281,274-281
 
 <!-- code_link_end -->
 
@@ -246,7 +246,7 @@ Consider the following worked example:
 
 [flow.Unpredictable]: ../../../../api/src/main/java/com/mastercard/test/flow/Unpredictable.java
 [AbstractMessage.masking(Unpredictable,UnaryOperator)]: ../../../../message/message-core/src/main/java/com/mastercard/test/flow/msg/AbstractMessage.java#L46-L53,46-53
-[AbstractFlocessor.masking(Unpredictable...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L201-L208,201-208
+[AbstractFlocessor.masking(Unpredictable...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L202-L209,202-209
 [mask.BenSys]: ../../test/java/com/mastercard/test/flow/doc/mask/BenSys.java
 [mask.DieSys]: ../../test/java/com/mastercard/test/flow/doc/mask/DieSys.java
 [mask.Unpredictables]: ../../test/java/com/mastercard/test/flow/doc/mask/Unpredictables.java
@@ -256,7 +256,7 @@ Consider the following worked example:
 [msg.Mask.andThen(Consumer)]: ../../../../message/message-core/src/main/java/com/mastercard/test/flow/msg/Mask.java#L290-L292,290-292
 [BenDiceTest?masking]: ../../test/java/com/mastercard/test/flow/doc/mask/BenDiceTest.java#L31,31
 [BenTest]: ../../test/java/com/mastercard/test/flow/doc/mask/BenTest.java
-[AbstractFlocessor.masking(Unpredictable...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L201-L208,201-208
+[AbstractFlocessor.masking(Unpredictable...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L202-L209,202-209
 
 <!-- code_link_end -->
 
@@ -276,7 +276,7 @@ You can see usage of these types in the example system:
 [flow.Context]: ../../../../api/src/main/java/com/mastercard/test/flow/Context.java
 [Builder.context(Context)]: ../../../../builder/src/main/java/com/mastercard/test/flow/builder/Builder.java#L225-L232,225-232
 [assrt.Applicator]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/Applicator.java
-[AbstractFlocessor.applicators(Applicator...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L247-L253,247-253
+[AbstractFlocessor.applicators(Applicator...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L248-L254,248-254
 [model.ctx.QueueProcessing]: ../../../../example/app-model/src/main/java/com/mastercard/test/flow/example/app/model/ctx/QueueProcessing.java
 [QueueProcessingApplicator]: ../../../../example/app-assert/src/main/java/com/mastercard/test/flow/example/app/assrt/ctx/QueueProcessingApplicator.java
 
@@ -299,7 +299,7 @@ You can see usage of these types in the example system:
 
 [flow.Residue]: ../../../../api/src/main/java/com/mastercard/test/flow/Residue.java
 [assrt.Checker]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/Checker.java
-[AbstractFlocessor.checkers(Checker...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L260-L266,260-266
+[AbstractFlocessor.checkers(Checker...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L261-L267,261-267
 [model.rsd.DBItems]: ../../../../example/app-model/src/main/java/com/mastercard/test/flow/example/app/model/rsd/DBItems.java
 [DBItemsChecker]: ../../../../example/app-assert/src/main/java/com/mastercard/test/flow/example/app/assrt/rsd/DBItemsChecker.java
 

--- a/doc/src/main/markdown/further.md
+++ b/doc/src/main/markdown/further.md
@@ -13,7 +13,7 @@ By default the report will be saved to a timestamped directory under `target/mct
 
 <!-- code_link_start -->
 
-[AbstractFlocessor.reporting(Reporting)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L182-L189,182-189
+[AbstractFlocessor.reporting(Reporting)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L189-L196,189-196
 [Reporting]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/Reporting.java
 
 <!-- code_link_end -->
@@ -78,8 +78,8 @@ Note that only the tag/index-based filtering can be used to avoid flow construct
 
 <!-- code_link_start -->
 
-[AbstractFlocessor.filtering(Consumer)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L279-L287,279-287
-[AbstractFlocessor.exercising(Predicate,Consumer)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L292-L317,292-317
+[AbstractFlocessor.filtering(Consumer)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L305-L313,305-313
+[AbstractFlocessor.exercising(Predicate,Consumer)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L318-L343,318-343
 
 <!-- code_link_end -->
 
@@ -123,7 +123,7 @@ Note that the assertion components will not make any assumptions about the forma
 [LogCapture]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/LogCapture.java
 [Tail]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/log/Tail.java
 [Merge]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/log/Merge.java
-[AbstractFlocessor.logs(LogCapture)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L247-L254,247-254
+[AbstractFlocessor.logs(LogCapture)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L273-L280,273-280
 
 <!-- code_link_end -->
 
@@ -246,7 +246,7 @@ Consider the following worked example:
 
 [flow.Unpredictable]: ../../../../api/src/main/java/com/mastercard/test/flow/Unpredictable.java
 [AbstractMessage.masking(Unpredictable,UnaryOperator)]: ../../../../message/message-core/src/main/java/com/mastercard/test/flow/msg/AbstractMessage.java#L46-L53,46-53
-[AbstractFlocessor.masking(Unpredictable...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L194-L201,194-201
+[AbstractFlocessor.masking(Unpredictable...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L201-L208,201-208
 [mask.BenSys]: ../../test/java/com/mastercard/test/flow/doc/mask/BenSys.java
 [mask.DieSys]: ../../test/java/com/mastercard/test/flow/doc/mask/DieSys.java
 [mask.Unpredictables]: ../../test/java/com/mastercard/test/flow/doc/mask/Unpredictables.java
@@ -256,7 +256,7 @@ Consider the following worked example:
 [msg.Mask.andThen(Consumer)]: ../../../../message/message-core/src/main/java/com/mastercard/test/flow/msg/Mask.java#L290-L292,290-292
 [BenDiceTest?masking]: ../../test/java/com/mastercard/test/flow/doc/mask/BenDiceTest.java#L31,31
 [BenTest]: ../../test/java/com/mastercard/test/flow/doc/mask/BenTest.java
-[AbstractFlocessor.masking(Unpredictable...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L194-L201,194-201
+[AbstractFlocessor.masking(Unpredictable...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L201-L208,201-208
 
 <!-- code_link_end -->
 
@@ -276,7 +276,7 @@ You can see usage of these types in the example system:
 [flow.Context]: ../../../../api/src/main/java/com/mastercard/test/flow/Context.java
 [Builder.context(Context)]: ../../../../builder/src/main/java/com/mastercard/test/flow/builder/Builder.java#L225-L232,225-232
 [assrt.Applicator]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/Applicator.java
-[AbstractFlocessor.applicators(Applicator...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L221-L227,221-227
+[AbstractFlocessor.applicators(Applicator...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L247-L253,247-253
 [model.ctx.QueueProcessing]: ../../../../example/app-model/src/main/java/com/mastercard/test/flow/example/app/model/ctx/QueueProcessing.java
 [QueueProcessingApplicator]: ../../../../example/app-assert/src/main/java/com/mastercard/test/flow/example/app/assrt/ctx/QueueProcessingApplicator.java
 
@@ -299,7 +299,7 @@ You can see usage of these types in the example system:
 
 [flow.Residue]: ../../../../api/src/main/java/com/mastercard/test/flow/Residue.java
 [assrt.Checker]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/Checker.java
-[AbstractFlocessor.checkers(Checker...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L234-L240,234-240
+[AbstractFlocessor.checkers(Checker...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L260-L266,260-266
 [model.rsd.DBItems]: ../../../../example/app-model/src/main/java/com/mastercard/test/flow/example/app/model/rsd/DBItems.java
 [DBItemsChecker]: ../../../../example/app-assert/src/main/java/com/mastercard/test/flow/example/app/assrt/rsd/DBItemsChecker.java
 


### PR DESCRIPTION
Flow works fine for synchronous systems (e.g.: A calls to B, which calls to C, which responds back to B, which responds back to A), where the system only does stuff in response to the test poking it with data.

Right now I'm adding tests to a system that includes a message queue that is working all the time regardless of test actions. I've got some flows that have the queue as the root cause, but in an integration test context there's nothing I can do with these flows - the root cause actor is part of the system under test. This is fine: those flows just get skipped and we have to assume that the stuff that the flows document _is_ happening in the system, even if we don't have any visibility of it.

The problem I hit today comes when you add _another_ flow that has the queue-rooted flow as a prerequisite - that new flow _also_ gets skipped as the assertion framework see the skipped prerequisite and throws a wobbler: the system is stateful, but the prerequisite didn't (as far as the test knows) happen, so we can't assume that the required state is in place for this new flow! We have to skip it!

This change adds a mechanism to avoid this: we've added a new flocessor configuration option that allows you to denote some system actors as being autonomous. Now instead of a flow just being skipped we can check if the root actor for that flow is autonomous. If it is then we tag that flow with a special `NOT_OBSERVED` result in the flow-result history that allows the test to assume that the flow actions _did_ happen, and so allow subsequent dependent flows to be processed as normal.