### PR TITLE
Added defensive copy mechanism

### DIFF
--- a/doc/src/main/markdown/further.md
+++ b/doc/src/main/markdown/further.md
@@ -245,12 +245,12 @@ Consider the following worked example:
 <!-- code_link_start -->
 
 [flow.Unpredictable]: ../../../../api/src/main/java/com/mastercard/test/flow/Unpredictable.java
-[AbstractMessage.masking(Unpredictable,UnaryOperator)]: ../../../../message/message-core/src/main/java/com/mastercard/test/flow/msg/AbstractMessage.java#L46-L53,46-53
+[AbstractMessage.masking(Unpredictable,UnaryOperator)]: ../../../../message/message-core/src/main/java/com/mastercard/test/flow/msg/AbstractMessage.java#L48-L55,48-55
 [AbstractFlocessor.masking(Unpredictable...)]: ../../../../assert/assert-core/src/main/java/com/mastercard/test/flow/assrt/AbstractFlocessor.java#L194-L201,194-201
 [mask.BenSys]: ../../test/java/com/mastercard/test/flow/doc/mask/BenSys.java
 [mask.DieSys]: ../../test/java/com/mastercard/test/flow/doc/mask/DieSys.java
 [mask.Unpredictables]: ../../test/java/com/mastercard/test/flow/doc/mask/Unpredictables.java
-[AbstractMessage.masking(Unpredictable,UnaryOperator)]: ../../../../message/message-core/src/main/java/com/mastercard/test/flow/msg/AbstractMessage.java#L46-L53,46-53
+[AbstractMessage.masking(Unpredictable,UnaryOperator)]: ../../../../message/message-core/src/main/java/com/mastercard/test/flow/msg/AbstractMessage.java#L48-L55,48-55
 [Rolling?d\+]: ../../test/java/com/mastercard/test/flow/doc/mask/Rolling.java#L30,30
 [msg.Mask]: ../../../../message/message-core/src/main/java/com/mastercard/test/flow/msg/Mask.java
 [msg.Mask.andThen(Consumer)]: ../../../../message/message-core/src/main/java/com/mastercard/test/flow/msg/Mask.java#L290-L292,290-292

--- a/message/message-core/src/main/java/com/mastercard/test/flow/msg/AbstractMessage.java
+++ b/message/message-core/src/main/java/com/mastercard/test/flow/msg/AbstractMessage.java
@@ -116,6 +116,9 @@ public abstract class AbstractMessage<T extends AbstractMessage<T>>
 	@Override
 	public final Object get( String field ) {
 		Object value = access( field );
+		if( value == null ) {
+			return null;
+		}
 		return defensiveCopiers.getOrDefault(
 				value.getClass(),
 				o -> o )

--- a/message/message-core/src/test/java/com/mastercard/test/flow/msg/AbstractMessageTest.java
+++ b/message/message-core/src/test/java/com/mastercard/test/flow/msg/AbstractMessageTest.java
@@ -224,6 +224,7 @@ class AbstractMessageTest {
 		msg.set( "biginteger", new BigInteger( "5678" ) );
 		msg.set( "uuid", new UUID( 12345L, 67890L ) );
 		msg.set( "timestamp", new Timestamp( 1234567890L ) );
+		msg.set( "null", null );
 
 		assertEquals( true, msg.get( "boolean" ) );
 		assertEquals( (byte) 1, msg.get( "byte" ) );
@@ -238,6 +239,8 @@ class AbstractMessageTest {
 		assertEquals( new BigInteger( "5678" ), msg.get( "biginteger" ) );
 		assertEquals( new UUID( 12345L, 67890L ), msg.get( "uuid" ) );
 		assertEquals( new Timestamp( 1234567890L ), msg.get( "timestamp" ) );
+		assertEquals( null, msg.get( "null" ) );
+		assertEquals( null, msg.get( "no such field" ) );
 	}
 
 	/**

--- a/message/message-core/src/test/java/com/mastercard/test/flow/msg/AbstractMessageTest.java
+++ b/message/message-core/src/test/java/com/mastercard/test/flow/msg/AbstractMessageTest.java
@@ -6,9 +6,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+import java.util.function.UnaryOperator;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -79,8 +85,12 @@ class AbstractMessageTest {
 		}
 
 		@Override
-		public Object get( String field ) {
-			throw new UnsupportedOperationException();
+		protected Object access( String field ) {
+			return updates.stream()
+					.filter( u -> u.field().equals( field ) )
+					.findAny()
+					.map( Update::value )
+					.orElse( null );
 		}
 
 		@Override
@@ -162,7 +172,7 @@ class AbstractMessageTest {
 	void mutableValues() throws Exception {
 
 		// pitest runs the test multiple times in the same classloader, so we have to
-		// clear the static immuatble type set back to default
+		// clear the static immutable type set back to default
 		Field f = AbstractMessage.class.getDeclaredField( "immutableTypes" );
 		f.setAccessible( true );
 		((Set<Class<?>>) f.get( null )).remove( ArrayList.class );
@@ -177,6 +187,9 @@ class AbstractMessageTest {
 				+ "If you're sure that this type is immutable, then you can call\n"
 				+ "  AbstractMessage.registerImmutable( EmptyList.class )\n"
 				+ "to suppress this error.\n"
+				+ "Alternatively you can use\n"
+				+ "  AbstractMessage.registerDefensiveCopier( type, function )\n"
+				+ "to make defensive copies of you mutable types.\n"
 				+ "You can also override\n"
 				+ "  AbstractMessage.validateValueType( field, value )\n"
 				+ "in your subclass implementation to do validation more suitable\n"
@@ -189,6 +202,106 @@ class AbstractMessageTest {
 		// doing
 		AbstractMessage.registerImmutable( ArrayList.class );
 		msg.set( "field", new ArrayList<>() );
+	}
+
+	/**
+	 * Runs through the default allowed types and shows they pass the mutability
+	 * filter
+	 */
+	@Test
+	void validTypes() {
+		ConcreteMessage msg = new ConcreteMessage( "msg" );
+		msg.set( "boolean", true );
+		msg.set( "byte", (byte) 1 );
+		msg.set( "short", (short) 2 );
+		msg.set( "character", 'a' );
+		msg.set( "integer", 4 );
+		msg.set( "float", 4.0f );
+		msg.set( "long", 8L );
+		msg.set( "double", 8.0 );
+		msg.set( "string", "bcd" );
+		msg.set( "bigdecimal", new BigDecimal( "1.234" ) );
+		msg.set( "biginteger", new BigInteger( "5678" ) );
+		msg.set( "uuid", new UUID( 12345L, 67890L ) );
+		msg.set( "timestamp", new Timestamp( 1234567890L ) );
+
+		assertEquals( true, msg.get( "boolean" ) );
+		assertEquals( (byte) 1, msg.get( "byte" ) );
+		assertEquals( (short) 2, msg.get( "short" ) );
+		assertEquals( 'a', msg.get( "character" ) );
+		assertEquals( 4, msg.get( "integer" ) );
+		assertEquals( 4.0f, msg.get( "float" ) );
+		assertEquals( 8L, msg.get( "long" ) );
+		assertEquals( 8.0, msg.get( "double" ) );
+		assertEquals( "bcd", msg.get( "string" ) );
+		assertEquals( new BigDecimal( "1.234" ), msg.get( "bigdecimal" ) );
+		assertEquals( new BigInteger( "5678" ), msg.get( "biginteger" ) );
+		assertEquals( new UUID( 12345L, 67890L ), msg.get( "uuid" ) );
+		assertEquals( new Timestamp( 1234567890L ), msg.get( "timestamp" ) );
+	}
+
+	/**
+	 * Demonstrates the mechanism that allows mutable field types to be used via
+	 * defensive copies
+	 *
+	 * @throws Exception if something goes wrong with our reflection
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	void defensiveCopy() throws Exception {
+
+		// pitest runs the test multiple times in the same classloader, so we have to
+		// clear the static copier map set back to default
+		Field f = AbstractMessage.class.getDeclaredField( "defensiveCopiers" );
+		f.setAccessible( true );
+		((Map<Class<?>, UnaryOperator<Object>>) f.get( null )).remove( StringBuilder.class );
+
+		ConcreteMessage msg = new ConcreteMessage( "msg" );
+
+		assertThrows( IllegalArgumentException.class,
+				() -> msg.set( "field", new StringBuilder( "buff" ) ) );
+
+		AbstractMessage.registerDefensiveCopier( StringBuilder.class,
+				b -> new StringBuilder( "copy of [" ).append( b.toString() ).append( "]" ) );
+
+		msg.set( "field", new StringBuilder( "buff" ) );
+
+		assertEquals( ""
+				+ "msg\n"
+				+ "  field=copy of [buff]",
+				msg.asHuman(),
+				"The message holds a defensive copy of the supplied value" );
+
+		assertEquals( "copy of [copy of [buff]]", msg.get( "field" ).toString(),
+				"When queried, the message returns a defensive copy of the held value" );
+	}
+
+	/**
+	 * Demonstrates that we reject ineffective defensive copiers
+	 *
+	 * @throws Exception if something goes wrong with our reflection
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	void badDefensiveCopy() throws Exception {
+
+		// pitest runs the test multiple times in the same classloader, so we have to
+		// clear the static copier map set back to default
+		Field f = AbstractMessage.class.getDeclaredField( "defensiveCopiers" );
+		f.setAccessible( true );
+		((Map<Class<?>, UnaryOperator<Object>>) f.get( null )).remove( StringBuilder.class );
+
+		ConcreteMessage msg = new ConcreteMessage( "msg" );
+
+		AbstractMessage.registerDefensiveCopier( StringBuilder.class,
+				b -> b );
+
+		IllegalStateException ise = assertThrows( IllegalStateException.class,
+				() -> msg.set( "field", new StringBuilder( "buff" ) ) );
+
+		assertEquals(
+				"Ineffective defensive copy for field 'field', type class java.lang.StringBuilder",
+				ise.getMessage() );
 	}
 
 	/**
@@ -214,6 +327,9 @@ class AbstractMessageTest {
 				+ "If you're sure that this type is immutable, then you can call\n"
 				+ "  AbstractMessage.registerImmutable( Object.class )\n"
 				+ "to suppress this error.\n"
+				+ "Alternatively you can use\n"
+				+ "  AbstractMessage.registerDefensiveCopier( type, function )\n"
+				+ "to make defensive copies of you mutable types.\n"
 				+ "You can also override\n"
 				+ "  AbstractMessage.validateValueType( field, value )\n"
 				+ "in your subclass implementation to do validation more suitable\n"

--- a/message/message-http/src/main/java/com/mastercard/test/flow/msg/http/HttpMsg.java
+++ b/message/message-http/src/main/java/com/mastercard/test/flow/msg/http/HttpMsg.java
@@ -124,7 +124,7 @@ public abstract class HttpMsg<T extends HttpMsg<T>> extends AbstractMessage<T> {
 	}
 
 	@Override
-	public Object get( String field ) {
+	protected Object access( String field ) {
 		if( BODY.equals( field ) ) {
 			return body.orElse( null );
 		}

--- a/message/message-json/src/main/java/com/mastercard/test/flow/msg/json/Json.java
+++ b/message/message-json/src/main/java/com/mastercard/test/flow/msg/json/Json.java
@@ -151,7 +151,7 @@ public class Json extends AbstractMessage<Json> {
 	}
 
 	@Override
-	public Object get( String field ) {
+	protected Object access( String field ) {
 		AtomicReference<Object> result = new AtomicReference<>();
 		traverse( data(), field, false,
 				( map, key ) -> result.set( map.get( key ) ),

--- a/message/message-sql/src/main/java/com/mastercard/test/flow/msg/sql/Query.java
+++ b/message/message-sql/src/main/java/com/mastercard/test/flow/msg/sql/Query.java
@@ -98,7 +98,7 @@ public class Query extends AbstractMessage<Query> {
 	}
 
 	@Override
-	public Object get( String field ) {
+	protected Object access( String field ) {
 		return data().get( field );
 	}
 

--- a/message/message-sql/src/main/java/com/mastercard/test/flow/msg/sql/Result.java
+++ b/message/message-sql/src/main/java/com/mastercard/test/flow/msg/sql/Result.java
@@ -173,7 +173,7 @@ public class Result extends AbstractMessage<Result> {
 	}
 
 	@Override
-	public Object get( String field ) {
+	protected Object access( String field ) {
 		ResultSetStructure data = data();
 		if( COLUMNS.equals( field ) ) {
 			return new ArrayList<>( data.columns );

--- a/message/message-text/src/main/java/com/mastercard/test/flow/msg/txt/Text.java
+++ b/message/message-text/src/main/java/com/mastercard/test/flow/msg/txt/Text.java
@@ -82,7 +82,7 @@ public class Text extends AbstractMessage<Text> {
 	}
 
 	@Override
-	public Object get( String field ) {
+	protected Object access( String field ) {
 		Matcher m = Pattern.compile( field ).matcher( build() );
 		if( m.find() ) {
 			return m.groupCount() == 0 ? m.group( 0 ) : m.group( 1 );

--- a/message/message-web/src/main/java/com/mastercard/test/flow/msg/web/WebSequence.java
+++ b/message/message-web/src/main/java/com/mastercard/test/flow/msg/web/WebSequence.java
@@ -139,7 +139,7 @@ public class WebSequence extends AbstractMessage<WebSequence> {
 	}
 
 	@Override
-	public Object get( String field ) {
+	protected Object access( String field ) {
 		return parameters().get( field );
 	}
 

--- a/message/message-xml/src/main/java/com/mastercard/test/flow/msg/xml/XML.java
+++ b/message/message-xml/src/main/java/com/mastercard/test/flow/msg/xml/XML.java
@@ -265,7 +265,7 @@ public class XML extends AbstractMessage<XML> {
 	}
 
 	@Override
-	public Object get( String field ) {
+	protected Object access( String field ) {
 		AtomicReference<Object> result = new AtomicReference<>();
 		traverse( data(), field, false, false,
 				( map, key ) -> result.set( map.get( key ) ),


### PR DESCRIPTION
It can be really bad if mutable fields are added to messages - if those values can get updated independently of the message you're left trying to find out why your message has changed when nothing is touching the message itself. It's a painful problem to debug.

Hence the message types are quite strict about what value types can be added - by default they only accept types that we know are immutable.
I've recently butted up against this limitation:
 * I wanted to add `java.util.UUID` values (the type is immutable)
 * I wanted to add `java.sql.Timestamp` values (this type is mutable, but it would be really convenient to use it directly)

This change:
 * Adds `UUID` to the set of immutable types
 * Adds a new mechanism for allowing mutable types as values: you can register a defensive copy function against a type. That function is used when the value is added to the message (we make a copy and store that instead) and when values are accessed from the message (we return a copy of the value that is held by the message)