### PR TITLE
Preserving execution reports from branches

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -58,7 +58,6 @@ jobs:
     permissions:
       contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
     needs: build
-    if: github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -78,7 +77,9 @@ jobs:
         path: mutation/ingest
 
     - name: Ingest
-      run: perl regen_index.pl >> $GITHUB_STEP_SUMMARY
+      run: perl regen_index.pl $GITHUB_HEAD_REF >> $GITHUB_STEP_SUMMARY
 
     - name: Commit
       uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4.16.0
+      with:
+        branch: pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         path: execution/ingest
 
     - name: Ingest
-      run: perl regen_index.pl ${$GITHUB_HEAD_REF} >> $GITHUB_STEP_SUMMARY
+      run: perl regen_index.pl ${$GITHUB_REF_NAME} >> $GITHUB_STEP_SUMMARY
 
     - name: Commit
       uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4.16.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,4 +71,6 @@ jobs:
 
     - name: Commit
       uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4.16.0
+      with:
+        branch: pages
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         path: execution/ingest
 
     - name: Ingest
-      run: perl regen_index.pl $GITHUB_REF_NAME >> $GITHUB_STEP_SUMMARY
+      run: perl regen_index.pl $GITHUB_HEAD_REF >> $GITHUB_STEP_SUMMARY
 
     - name: Commit
       uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4.16.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         path: execution/ingest
 
     - name: Ingest
-      run: perl regen_index.pl ${$GITHUB_REF_NAME} >> $GITHUB_STEP_SUMMARY
+      run: perl regen_index.pl $GITHUB_REF_NAME >> $GITHUB_STEP_SUMMARY
 
     - name: Commit
       uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4.16.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,4 +73,3 @@ jobs:
       uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4.16.0
       with:
         branch: pages
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,6 @@ jobs:
     permissions:
       contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
     needs: build
-    if: github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -68,7 +67,7 @@ jobs:
         path: execution/ingest
 
     - name: Ingest
-      run: perl regen_index.pl >> $GITHUB_STEP_SUMMARY
+      run: perl regen_index.pl ${GITHUB_REF#refs/heads/} >> $GITHUB_STEP_SUMMARY
 
     - name: Commit
       uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4.16.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         path: execution/ingest
 
     - name: Ingest
-      run: perl regen_index.pl ${GITHUB_REF#refs/heads/} >> $GITHUB_STEP_SUMMARY
+      run: perl regen_index.pl ${$GITHUB_HEAD_REF} >> $GITHUB_STEP_SUMMARY
 
     - name: Commit
       uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4.16.0


### PR DESCRIPTION
One of the main points of this project is to produce nice testing reports, so it's quite annoying that by default github will only allow you to [download a zip of content produced by CI actions](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts).
Having to download a zip, extract it, then viewing those files in a browser is _super-lame_. In addition, there's some really nice report functionalities (the [model diff](https://mastercard.github.io/flow/execution/latest/flow_execution_reports/example/app-itest/target/mctf/latest/index.html#/diff) and the [basis diff](https://mastercard.github.io/flow/execution/latest/flow_execution_reports/example/app-itest/target/mctf/latest/detail/7E22263CB3957E4841C81B8933D5CB47.html#/?msg=5&display=Basis)) that only work when the report is properly served and so supports ajax stuff.

This CI actions weakness is [tracked here](https://github.com/actions/upload-artifact/issues/14). We've come up with a not-great-but-better-than-downloading-zips workaround for this using [github pages](https://pages.github.com/), [described here](https://github.com/actions/upload-artifact/issues/14#issuecomment-1213015260). Right now this workaround only operates on CI actions on the `main` branch, but it'd be nice to also publish reports from other branches so you can:
 * Use the model diff tooling when you change the [example application system model](https://github.com/Mastercard/flow/tree/main/example/app-model).
 * More likely: look at the mutation testing report to see why your PR is failing the [thresholds](https://github.com/Mastercard/flow/blob/main/api/pom.xml#L35-L39)

Hence, fixing #251, we're:
 * Having the publish jobs run on all branches
 * Passing the branch name to our report ingestion script
 * Configuring the pages branch name on the commit step. Not sure why we needed to do that, but we do - otherwise the git-auto-commit-action tries to check out the merge branch, which we don't want.

Over on the `pages` branch we've updated the [ingestion script](https://github.com/Mastercard/flow/blob/pages/regen_index.pl) to:
 * Accept the branch name as a command-line argument
 * Save that value to a file inside the ingested reports
 * Read the saved branch names from the file when we spider over the file system to generate the report index table
 * Add a new column in the table with the branch name values.

It turns out to be amazingly difficult to show the diff of a single file between commits in github, so you'll just have to look at [the recent commits on that file](https://github.com/Mastercard/flow/commits/pages/regen_index.pl) to see what I did.

You can already see the effects of the ingestion script change on the [deployed `pages` page](https://mastercard.github.io/flow/) - we've got a new column in the tables with the branch name that produced the results. Right now there's a bunch of new results from the `main` branch from this morning's dependabot PR spree, but you can also see couple from this branch below those.