### PR TITLE
Avoiding publish collisions

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -12,7 +12,6 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     env:
       LANG: en_GB
@@ -60,6 +59,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     continue-on-error: true
+    concurrency: pages_branch
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     continue-on-error: true
+    concurrency: pages_branch
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1


### PR DESCRIPTION
#294 enabled the publishing of test reports from PR branches. This morning's bolus of dependabot PRs exposed a weakness - a bunch of the publish jobs failed as they were trying to update the `pages` branch at the same time, so there was a race condition where the losers failed on the `git push` - their commit history was suddenly out-of-date.

This change should mitigate that via the [job-level concurrency control](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idconcurrency) - now only one instance of the publish job should have access to the `pages` branch at a time,