### PR TITLE
Updated the UI less often when loading models for diffing

### DIFF
--- a/report/report-ng/projects/report/src/app/flow-diff.service.ts
+++ b/report/report-ng/projects/report/src/app/flow-diff.service.ts
@@ -90,6 +90,7 @@ export class FlowDiffService {
       }
     });
 
+    let lastRefresh = Date.now();
     mdds.onFlow("from", (label, entry, flow) => {
       this.sourceData.forEach(dp => {
         if (dp.left !== null && dp.left.entry.detail === entry.detail) {
@@ -98,9 +99,13 @@ export class FlowDiffService {
         }
       }
       );
-      this.rebuildChanges();
-      this.recollateChanges();
-      this.refreshListeners.forEach(cb => cb());
+      let delta = Date.now() - lastRefresh;
+      if (mdds.flowLoadProgress("from") == 100 || delta > 3000) {
+        this.rebuildChanges();
+        this.recollateChanges();
+        this.refreshListeners.forEach(cb => cb());
+        lastRefresh = Date.now();
+      }
     });
     mdds.onFlow("to", (label, entry, flow) => {
       this.sourceData.forEach(dp => {
@@ -110,9 +115,13 @@ export class FlowDiffService {
         }
       }
       );
-      this.rebuildChanges();
-      this.recollateChanges();
-      this.refreshListeners.forEach(cb => cb());
+      let delta = Date.now() - lastRefresh;
+      if (mdds.flowLoadProgress("to") == 100 || delta > 3000) {
+        this.rebuildChanges();
+        this.recollateChanges();
+        this.refreshListeners.forEach(cb => cb());
+        lastRefresh = Date.now();
+      }
     });
   }
 


### PR DESCRIPTION
Fixes #320, we're gating our previously per-loaded-flow UI updates to instead happen:
 * Every three seconds
 * When all flows for a model are loaded

Even with the small size of the example system model, you can seen an appreciable difference in loading speed between [before](https://mastercard.github.io/flow/execution/1679908788/flow_execution_reports/example/app-itest/target/mctf/latest/index.html#/diff) and [after](https://mastercard.github.io/flow/execution/1680271707/flow_execution_reports/example/app-itest/target/mctf/latest/index.html#/diff) this change