### PR TITLE
Mermaid details

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ These tests produce a rich execution report, [for example](https://mastercard.gi
  * [Further reading](doc/src/main/markdown/further.md): Covers more advanced usage.
  * The submodules under [example](example) illustrate a complete service constellation with flow-based testing
 
-## Artifact dependency structure
+<details>
+<summary>Artifact dependency structure</summary>
 
 <!-- start_module_diagram:framework -->
 
@@ -72,7 +73,7 @@ graph TB
 ```
 
 <!-- end_module_diagram -->
-
+</details>
 
 ## Links
 

--- a/api/src/main/java/com/mastercard/test/flow/FieldAddress.java
+++ b/api/src/main/java/com/mastercard/test/flow/FieldAddress.java
@@ -38,6 +38,9 @@ public interface FieldAddress {
 	String field();
 
 	/**
+	 * Determines if the address is fully-specified, i.e.: it unambiguously
+	 * identifies a single field in a single message in a single flow
+	 *
 	 * @return <code>true</code> if this address is complete
 	 */
 	default boolean isComplete() {

--- a/api/src/main/java/com/mastercard/test/flow/util/Transmission.java
+++ b/api/src/main/java/com/mastercard/test/flow/util/Transmission.java
@@ -120,7 +120,10 @@ public class Transmission {
 	}
 
 	/**
-	 * @return A string that describes the transmission, but with no tags
+	 * Constructs a string that describes the transmission, but with no tag
+	 * information
+	 *
+	 * @return An untagged description
 	 */
 	public String toUntaggedString() {
 		StringBuilder sb = new StringBuilder();

--- a/assert/assert-filter/src/main/java/com/mastercard/test/flow/assrt/filter/gui/FilterGui.java
+++ b/assert/assert-filter/src/main/java/com/mastercard/test/flow/assrt/filter/gui/FilterGui.java
@@ -36,7 +36,9 @@ import com.mastercard.test.flow.assrt.filter.FilterOptions;
 public class FilterGui {
 
 	/**
-	 * @return <code>true</code> if the gui should be invoked
+	 * Determines if the gui should be shown
+	 *
+	 * @return <code>true</code> if the gui should be shown
 	 */
 	public static boolean requested() {
 		return "gui".equals( FilterOptions.FILTER_UPDATE.value() )

--- a/builder/src/main/java/com/mastercard/test/flow/builder/Builder.java
+++ b/builder/src/main/java/com/mastercard/test/flow/builder/Builder.java
@@ -273,6 +273,8 @@ public abstract class Builder<T extends Builder<T>> {
 	}
 
 	/**
+	 * Typed self-reference accessor
+	 *
 	 * @return <code>this</code>
 	 */
 	@SuppressWarnings("unchecked")

--- a/builder/src/main/java/com/mastercard/test/flow/builder/mutable/MutableDependency.java
+++ b/builder/src/main/java/com/mastercard/test/flow/builder/mutable/MutableDependency.java
@@ -68,6 +68,8 @@ public class MutableDependency {
 	}
 
 	/**
+	 * Builds an immutable copy of the current state
+	 *
 	 * @param defaultFlow The {@link Flow} to use if the {@link Flow} in the field
 	 *                    addresses is <code>null</code>
 	 * @return The immutable version of the current state

--- a/builder/src/main/java/com/mastercard/test/flow/builder/mutable/MutableFieldAddress.java
+++ b/builder/src/main/java/com/mastercard/test/flow/builder/mutable/MutableFieldAddress.java
@@ -81,6 +81,8 @@ public class MutableFieldAddress {
 	}
 
 	/**
+	 * Builds an immutable copy of the current state
+	 *
 	 * @param defaultFlow The {@link Flow} to use if the {@link Flow} in this object
 	 *                    is <code>null</code>
 	 * @return The immutable version of the current state

--- a/builder/src/main/java/com/mastercard/test/flow/builder/mutable/MutableFlow.java
+++ b/builder/src/main/java/com/mastercard/test/flow/builder/mutable/MutableFlow.java
@@ -190,6 +190,8 @@ public class MutableFlow {
 	}
 
 	/**
+	 * Builds an immutable copy of the current state
+	 *
 	 * @return An immutable {@link Flow} instance
 	 */
 	public Flow build() {

--- a/builder/src/main/java/com/mastercard/test/flow/builder/mutable/MutableInteraction.java
+++ b/builder/src/main/java/com/mastercard/test/flow/builder/mutable/MutableInteraction.java
@@ -163,6 +163,8 @@ public class MutableInteraction implements Interaction {
 	}
 
 	/**
+	 * Builds an immutable copy of the current state
+	 *
 	 * @param p The {@link Interaction} that caused this one
 	 * @return An immutable {@link Interaction} instance
 	 */

--- a/builder/src/main/java/com/mastercard/test/flow/builder/mutable/MutableMetadata.java
+++ b/builder/src/main/java/com/mastercard/test/flow/builder/mutable/MutableMetadata.java
@@ -114,6 +114,8 @@ public class MutableMetadata {
 	}
 
 	/**
+	 * Builds an immutable copy of the current state
+	 *
 	 * @return An immutable {@link Metadata} instance
 	 */
 	public ConcreteMetadata build() {

--- a/builder/src/main/java/com/mastercard/test/flow/builder/mutable/MutableRootInteraction.java
+++ b/builder/src/main/java/com/mastercard/test/flow/builder/mutable/MutableRootInteraction.java
@@ -38,6 +38,8 @@ public class MutableRootInteraction extends MutableInteraction {
 	}
 
 	/**
+	 * Builds an immutable copy of the current state
+	 *
 	 * @return An immutable {@link Interaction} instance
 	 */
 	public ConcreteRootInteraction build() {

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -68,15 +68,6 @@
 			<version>${project.version}</version>
 		</dependency>
 
-		<!-- snippet-start:validation -->
-		<dependency>
-			<!-- system model validation -->
-			<groupId>com.mastercard.test.flow</groupId>
-			<artifactId>validation-junit5</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<!-- snippet-end:validation -->
-
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>report-core</artifactId>
@@ -95,12 +86,23 @@
 			<version>${project.version}</version>
 		</dependency>
 
+		<!-- snippet-start:validation -->
+		<dependency>
+			<!-- system model validation -->
+			<groupId>com.mastercard.test.flow</groupId>
+			<artifactId>validation-junit5</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- snippet-end:validation -->
+
 		<!-- snippet-start:assertion -->
 		<dependency>
 			<!-- system assertion -->
 			<groupId>com.mastercard.test.flow</groupId>
 			<artifactId>assert-junit5</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<!-- snippet-end:assertion -->
 

--- a/doc/src/main/markdown/quickstart.md
+++ b/doc/src/main/markdown/quickstart.md
@@ -241,9 +241,10 @@ To use these, add a dependency:
 	<groupId>com.mastercard.test.flow</groupId>
 	<artifactId>validation-junit5</artifactId>
 	<version>${flow.version}</version>
+	<scope>test</scope>
 </dependency>
 ```
-[Snippet context](../../../pom.xml#L72-L77,72-77)
+[Snippet context](../../../pom.xml#L90-L96,90-96)
 
 <!-- snippet end -->
 
@@ -292,9 +293,10 @@ Add a dependency:
 	<groupId>com.mastercard.test.flow</groupId>
 	<artifactId>assert-junit5</artifactId>
 	<version>${flow.version}</version>
+	<scope>test</scope>
 </dependency>
 ```
-[Snippet context](../../../pom.xml#L99-L104,99-104)
+[Snippet context](../../../pom.xml#L100-L106,100-106)
 
 <!-- snippet end -->
 

--- a/example/README.md
+++ b/example/README.md
@@ -60,9 +60,9 @@ graph TD
 
 <!-- system_diagram_end -->
 
-## Artifact dependency structure
-
-Solid lines are <code>compile</code>-scope dependencies, dotted are <code>test</code>-scope.
+<details>
+<summary>Artifact dependency structure</summary>
+    Solid lines are <code>compile</code>-scope dependencies, dotted are <code>test</code>-scope.
 
 <!-- start_module_diagram:example -->
 
@@ -126,6 +126,7 @@ graph LR
 ```
 
 <!-- end_module_diagram -->
+</details>
 
 ## Starting the services
 

--- a/message/message-core/src/main/java/com/mastercard/test/flow/msg/AbstractMessage.java
+++ b/message/message-core/src/main/java/com/mastercard/test/flow/msg/AbstractMessage.java
@@ -253,14 +253,18 @@ public abstract class AbstractMessage<T extends AbstractMessage<T>>
 		}
 
 		/**
-		 * @return The field address
+		 * Gets the field address
+		 *
+		 * @return The address of the field to update
 		 */
 		public String field() {
 			return field;
 		}
 
 		/**
-		 * @return The new field value
+		 * Gets the field value
+		 *
+		 * @return The new value of the updated field
 		 */
 		public Object value() {
 			return value;

--- a/message/message-core/src/main/java/com/mastercard/test/flow/msg/ExposedMasking.java
+++ b/message/message-core/src/main/java/com/mastercard/test/flow/msg/ExposedMasking.java
@@ -27,6 +27,8 @@ import com.mastercard.test.flow.Unpredictable;
 public interface ExposedMasking extends Message {
 
 	/**
+	 * Accessor for masking operations.
+	 *
 	 * @return The sources of {@link Unpredictable} data for which this message has
 	 *         masking operations
 	 */

--- a/message/message-http/src/main/java/com/mastercard/test/flow/msg/http/HttpMsg.java
+++ b/message/message-http/src/main/java/com/mastercard/test/flow/msg/http/HttpMsg.java
@@ -137,6 +137,8 @@ public abstract class HttpMsg<T extends HttpMsg<T>> extends AbstractMessage<T> {
 	}
 
 	/**
+	 * Determines if an address targets a field in the HTTP message
+	 *
 	 * @param field a field name
 	 * @return <code>true</code> if the supplied field relates to the HTTP message
 	 *         and not the body message
@@ -212,6 +214,8 @@ public abstract class HttpMsg<T extends HttpMsg<T>> extends AbstractMessage<T> {
 	}
 
 	/**
+	 * Computes the final set of field values
+	 *
 	 * @return The final message data
 	 */
 	protected Map<String, Object> data() {
@@ -228,7 +232,9 @@ public abstract class HttpMsg<T extends HttpMsg<T>> extends AbstractMessage<T> {
 	}
 
 	/**
-	 * @return message headers
+	 * Accesses HTTP header values
+	 *
+	 * @return name/values map of message headers
 	 */
 	public Map<String, String> headers() {
 		Map<String, String> headers = new TreeMap<>();
@@ -239,6 +245,8 @@ public abstract class HttpMsg<T extends HttpMsg<T>> extends AbstractMessage<T> {
 	}
 
 	/**
+	 * Determines if an address targets a header field
+	 *
 	 * @param field a field name
 	 * @return <code>true</code> if the supplied field should be populated in the
 	 *         header
@@ -275,6 +283,8 @@ public abstract class HttpMsg<T extends HttpMsg<T>> extends AbstractMessage<T> {
 	}
 
 	/**
+	 * Gets the HTTP version value
+	 *
 	 * @return message HTTP version
 	 */
 	public String version() {
@@ -282,6 +292,8 @@ public abstract class HttpMsg<T extends HttpMsg<T>> extends AbstractMessage<T> {
 	}
 
 	/**
+	 * Gets the body {@link Message}
+	 *
 	 * @return message body as a {@link Message} object
 	 */
 	public Optional<ExposedMasking> body() {
@@ -289,6 +301,8 @@ public abstract class HttpMsg<T extends HttpMsg<T>> extends AbstractMessage<T> {
 	}
 
 	/**
+	 * Gets the body content
+	 *
 	 * @return The text of the message body as a string
 	 */
 	public String bodyText() {


### PR DESCRIPTION
The artifact structure diagrams are kind of large, so we used to display them in a `<details>` block.
At some point github changed something on their end which broke this usage, so we had to #196 to just display the diagrams all the time.
We raised an issue with github to get their regression fixed. That issue is still open, but it looks like the problem has gone away. ¯\_(ツ)_/¯

Also in this changeset: some documentation fixes