### PR TITLE
Fixed mutant

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Save project mutation reports
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-      if: failure()
+      if:  ${{ failure() }}
       with:
         name: project_mutation_reports
         path: '**/target/pit-reports'

--- a/validation/validation-core/src/test/java/com/mastercard/test/flow/validation/graph/DAGTest.java
+++ b/validation/validation-core/src/test/java/com/mastercard/test/flow/validation/graph/DAGTest.java
@@ -1,0 +1,37 @@
+package com.mastercard.test.flow.validation.graph;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reaches the parts of {@link DAG} that other tests don't
+ */
+@SuppressWarnings("static-method")
+class DAGTest {
+
+	/**
+	 * Children are stringified in lexicographical order
+	 */
+	@Test
+	void toStringOrder() {
+		DAG<String> root = new DAG<>( "root" );
+		Stream.of( "jihbacfged".split( "" ) )
+				.forEach( root::withChild );
+
+		assertEquals( ""
+				+ "root\n"
+				+ "├a\n"
+				+ "├b\n"
+				+ "├c\n"
+				+ "├d\n"
+				+ "├e\n"
+				+ "├f\n"
+				+ "├g\n"
+				+ "├h\n"
+				+ "├i\n"
+				+ "└j", root.toString() );
+	}
+}


### PR DESCRIPTION
A new mutant appeared today - item were being returned from a `HashSet` in the desired lexicographical order, so testing complained that it could mutate our comparator to return 0 without breaking any tests.

We're adding a new test to directly provoke the behaviour