### PR TITLE
Fixed links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Testing framework
 
 This project provides a framework in which the flow of data in a system can be modelled.
 This model can then be used to drive testing, both of the complete system and of subsystems in isolation.
-These tests produce a rich execution report, [for example](https://mastercard.github.io/flow/execution/latest/flow_execution_reports/example/app-itest/target/mctf/latest/index.html).
+These tests produce a rich execution report, [for example](https://mastercard.github.io/flow/execution/latest/example/app-itest/target/mctf/latest/index.html).
 
 [This document describes the motivations for this approach](doc/src/main/markdown/motivation/index.md).
 

--- a/doc/src/main/markdown/motivation/index.md
+++ b/doc/src/main/markdown/motivation/index.md
@@ -204,6 +204,6 @@ While it is important that tests are automated, stable, quick and easy to run, a
 ---
 
  * [Project root](https://github.com/Mastercard/flow)
- * [Example execution report](https://mastercard.github.io/flow/execution/latest/flow_execution_reports/example/app-itest/target/mctf/latest/index.html)
+ * [Example execution report](https://mastercard.github.io/flow/execution/latest/example/app-itest/target/mctf/latest/index.html)
  * [Quickstart guide](../quickstart.md)
  * [Further reading](../further.md)


### PR DESCRIPTION
#407 changed our download-artifact usage to fetch a named artifact rather than all of them. As a result we no longer get the artifact name in the resulting path.