### PR TITLE
Added changelog automation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,18 @@
+name: Changelog
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  changelog:
+    name: Update changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: main
+      - uses: rhysd/changelog-from-release/action@ce14e29aaf6ccba000120b741292eabe1d7ea485 # v3.7.1
+        with:
+          file: CHANGELOG.md
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,0 @@
-# Changelog
-
-## Version 0.01
-
- * In the beginning...


### PR DESCRIPTION
We like the github release notes stuff, but we _also_ like having that data in a file in the repo as well as wherever github is storing it.
Hence we're adding automation to dump new release notes into the changelog file.