### PR TITLE
Semantic diffs aren't very helpful for us

### DIFF
--- a/example/app-assert/src/main/java/com/mastercard/test/flow/example/app/assrt/Browser.java
+++ b/example/app-assert/src/main/java/com/mastercard/test/flow/example/app/assrt/Browser.java
@@ -84,8 +84,7 @@ public class Browser implements
 			// https://github.com/SeleniumHQ/selenium/issues/11750
 			options.addArguments( "--remote-allow-origins=*" );
 
-			// suppress most stdout noise. We still get a "ChromeDriver was started
-			// successfully." line for some reason
+			// suppress stdout noise
 			System.setProperty( CHROME_DRIVER_SILENT_OUTPUT_PROPERTY, "true" );
 			Logger.getLogger( "org.openqa.selenium" ).setLevel( Level.OFF );
 
@@ -133,9 +132,6 @@ public class Browser implements
 
 	private static void quitBrowser() {
 		if( driver != null ) {
-			// chromedriver seems to have an impossible-to-suppress stderr line on startup,
-			// so it's only fair that we mirror that on shutdown
-			System.err.println( "Shutting down Chrome" );
 			driver.quit();
 			driver = null;
 		}

--- a/report/report-core/src/test/java/com/mastercard/test/flow/report/diff/ModelDiffTest.java
+++ b/report/report-core/src/test/java/com/mastercard/test/flow/report/diff/ModelDiffTest.java
@@ -355,29 +355,29 @@ class ModelDiffTest {
 						"Unchanged 1 On tags: b c d 1 never changed: b" );
 
 		dseq.analysisDiffs(
-				"14 characters on 1 flow c d e B ii Bee ee oo aa" )
-				.expandAnalysis( "14 characters on 1 flow c d e B ii Bee ee oo aa" )
+				"8 characters on 1 flow c d e ii ee oo aa" )
+				.expandAnalysis( "8 characters on 1 flow c d e ii ee oo aa" )
 				.hasSubjectFlows(
 						"updated c d e | updated c d e" );
 
 		dseq.clickDiff( 0 )
 				.hasDiff(
-						" 1   - Identity:                ",
-						" 2   -   removed                ",
-						" 3   -   a                      ",
-						" 4   -   b                      ",
-						" 5   -   c                      ",
-						" 6   - Motivation:              ",
-						" 7   -                          ",
-						" 8   - Context:                 ",
-						" 9   -   {}                     ",
-						"10   - Interactions:            ",
-						"11   -   ┌REQUEST AVA => BEN [] ",
-						"12   -   │Hi Ben!               ",
-						"13   -   └                      ",
-						"14   -   ┌RESPONSE AVA <= BEN []",
-						"15   -   │Hello Ava!            ",
-						"16   -   └                      " );
+						" 1  1   Identity:                ",
+						" 2  2     updated                ",
+						" 3  3     c                      ",
+						" 4  4     d                      ",
+						"        3 unchanged lines        ",
+						" 8  8   Context:                 ",
+						" 9  9     {}                     ",
+						"10 10   Interactions:            ",
+						"11 11     ┌REQUEST AVA => BEN [] ",
+						"12    -   │Hi Ben!               ",
+						"   12 +   │Hiii Beeen!           ",
+						"13 13     └                      ",
+						"14 14     ┌RESPONSE AVA <= BEN []",
+						"15    -   │Hello Ava!            ",
+						"   15 +   │Heeellooo Avaaa!      ",
+						"16 16     └                      " );
 	}
 
 	/**
@@ -525,8 +525,8 @@ class ModelDiffTest {
 						"Changed 2 On tags: a b c d e f 3 always changed: a e f",
 						"Unchanged 1 On tags: b c d 0 never changed:" )
 				.analysisDiffs(
-						"30 characters on 1 flow a b c d e remov updat a c b d c e B ii Bee ee oo aa",
-						"16 characters on 1 flow c d e f updat add c f" );
+						"24 characters on 1 flow a b c d e remov updat a c b d c e ii ee oo aa",
+						"14 characters on 1 flow c d e f upd t dd c f" );
 
 	}
 }

--- a/report/report-core/src/test/java/com/mastercard/test/flow/report/seq/Browser.java
+++ b/report/report-core/src/test/java/com/mastercard/test/flow/report/seq/Browser.java
@@ -131,9 +131,6 @@ public class Browser implements
 
 	private static void quitBrowser() {
 		if( driver != null ) {
-			// chromedriver seems to have an impossible-to-suppress stderr line on startup,
-			// so it's only fair that we mirror that on shutdown
-			System.err.println( "Shutting down browser" );
 			driver.quit();
 			driver = null;
 		}
@@ -158,8 +155,7 @@ public class Browser implements
 				// https://github.com/SeleniumHQ/selenium/issues/11750
 				options.addArguments( "--remote-allow-origins=*" );
 
-				// suppress most stdout noise. We still get a "ChromeDriver was started
-				// successfully." line for some reason
+				// suppress stdout noise
 				System.setProperty( CHROME_DRIVER_SILENT_OUTPUT_PROPERTY, "true" );
 				Logger.getLogger( "org.openqa.selenium" ).setLevel( Level.OFF );
 

--- a/report/report-ng/projects/report/src/app/change-view/change-view.component.ts
+++ b/report/report-ng/projects/report/src/app/change-view/change-view.component.ts
@@ -116,6 +116,9 @@ export class ChangeViewComponent implements OnInit {
     if (this.selected === null && this.all.length > 0) {
       this.selected = this.all[0];
     }
+
+    this.refreshDiff();
+    this.selectionListeners.forEach(cb => cb());
   }
 
   buildQuery(usp: URLSearchParams): URLSearchParams {

--- a/report/report-ng/projects/report/src/app/flow-diff.service.ts
+++ b/report/report-ng/projects/report/src/app/flow-diff.service.ts
@@ -235,7 +235,6 @@ export class FlowDiffService {
         let diffs: Diff[] = this.dmp.diff_main(
           pair.left?.flat ?? '',
           pair.right?.flat ?? '');
-        this.dmp.diff_cleanupSemantic(diffs);
 
         diffs
           .filter(d => d[0] !== DIFF_EQUAL)

--- a/report/report-ng/projects/report/src/app/seq-action/seq-action.component.ts
+++ b/report/report-ng/projects/report/src/app/seq-action/seq-action.component.ts
@@ -106,7 +106,6 @@ export class SeqActionComponent implements OnInit {
     }
 
     let diffs: Diff[] = this.dmp.diff_main(full, asserted);
-    this.dmp.diff_cleanupSemantic(diffs);
 
     // levenshtein distance is the number of changed characters - minimum
     // is 0, maximum is the length of the longer input string


### PR DESCRIPTION
We use [diff-match-patch](https://github.com/google/diff-match-patch) in the report app for three things:
 * The text diff component
 * The coverage indicator
 * The model change analysis

For the first of these usages we saw that the [diff_cleanupSemantic](https://github.com/google/diff-match-patch/wiki/API#diff_cleanupsemanticdiffs--null) wasn't actually very helpful for the sort of text that we were working with, so we left it out.

That method was already being called for the other two usages - this change removes those calls so that all diff operations are consistent.

In the process of this change we noticed that:
 * Chrome is no longer putting a startup notice on stderr - we can remove our own shutdown notice
 * Click from the model change analysis page to a change didn't work as expected - the diff component wasn't being refreshed correctly.