### PR TITLE
Improved linux behaviours

### DIFF
--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -18,19 +18,19 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.mastercard.test.flow</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>builder</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.mastercard.test.flow</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>message-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.mastercard.test.flow</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>message-text</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -66,7 +66,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.mastercard.test.flow</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>model</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -84,13 +84,13 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.mastercard.test.flow</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>validation-junit5</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.mastercard.test.flow</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>coppice</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -120,7 +120,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.mastercard.test.flow</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>assert-junit5</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/api/src/test/java/com/mastercard/test/flow/util/OptionTest.java
+++ b/api/src/test/java/com/mastercard/test/flow/util/OptionTest.java
@@ -151,9 +151,7 @@ class OptionTest {
 		// invalid value, no default
 		Option noDefault = new Builder().property( "tstopt" );
 		noDefault.set( "not an int" );
-		assertEquals( "null",
-				assertThrows( NumberFormatException.class, () -> noDefault.asInt() )
-						.getMessage() );
+		assertThrows( NumberFormatException.class, () -> noDefault.asInt() );
 
 		// invalid value, invalid default
 		Option badDefault = new Builder().property( "tstopt" ).defaultValue( "not an int either" );

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,19 +20,19 @@
 			</dependency>
 
 			<dependency>
-				<groupId>com.mastercard.test.flow</groupId>
+				<groupId>${project.groupId}</groupId>
 				<artifactId>builder</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 
 			<dependency>
-				<groupId>com.mastercard.test.flow</groupId>
+				<groupId>${project.groupId}</groupId>
 				<artifactId>message-core</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 
 			<dependency>
-				<groupId>com.mastercard.test.flow</groupId>
+				<groupId>${project.groupId}</groupId>
 				<artifactId>message-text</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -68,7 +68,7 @@
 			</dependency>
 
 			<dependency>
-				<groupId>com.mastercard.test.flow</groupId>
+				<groupId>${project.groupId}</groupId>
 				<artifactId>model</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -86,13 +86,13 @@
 			</dependency>
 
 			<dependency>
-				<groupId>com.mastercard.test.flow</groupId>
+				<groupId>${project.groupId}</groupId>
 				<artifactId>validation-junit5</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 
 			<dependency>
-				<groupId>com.mastercard.test.flow</groupId>
+				<groupId>${project.groupId}</groupId>
 				<artifactId>coppice</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -122,7 +122,7 @@
 			</dependency>
 
 			<dependency>
-				<groupId>com.mastercard.test.flow</groupId>
+				<groupId>${project.groupId}</groupId>
 				<artifactId>assert-junit5</artifactId>
 				<version>${project.version}</version>
 			</dependency>

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -14,7 +14,7 @@
 		<dependencies>
 			<dependency>
 				<!-- controls flow artifact versions -->
-				<groupId>com.mastercard.test.flow</groupId>
+				<groupId>${project.groupId}</groupId>
 				<artifactId>bom</artifactId>
 				<version>${project.version}</version>
 				<type>pom</type>

--- a/doc/src/test/java/com/mastercard/test/flow/doc/SnippetTest.java
+++ b/doc/src/test/java/com/mastercard/test/flow/doc/SnippetTest.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -22,7 +21,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestFactory;
 
 /**
@@ -130,23 +128,18 @@ class SnippetTest {
 			if( ex == null ) {
 
 				String content = new String( Files.readAllBytes( file ), UTF_8 );
-				Iterator<String> lines = Arrays.asList( content.split( "\n", -1 ) ).iterator();
 				Map<String, Snippet> extant = new HashMap<>();
 				int lineNumber = 0;
 
-				while( lines.hasNext() ) {
+				for( String line : Arrays.asList( content.split( "\n", -1 ) ) ) {
 					lineNumber++;
-					String line = lines.next();
-
 					Delimiter sd = delimiter( file );
 					Matcher start = sd.start.matcher( line.trim() );
 					Matcher end = sd.end.matcher( line.trim() );
 					if( start.matches() ) {
-
 						extant.put( start.group( 1 ), new Snippet( file, lineNumber + 1 ) );
 					}
 					else if( end.matches() ) {
-
 						excerpts.put( file + ":" + end.group( 1 ),
 								extant.remove( end.group( 1 ) ) );
 					}

--- a/example/app-itest/src/test/java/com/mastercard/test/flow/example/app/itest/IntegrationTest.java
+++ b/example/app-itest/src/test/java/com/mastercard/test/flow/example/app/itest/IntegrationTest.java
@@ -14,6 +14,7 @@ import static com.mastercard.test.flow.example.app.model.ExampleSystem.Unpredict
 import static com.mastercard.test.flow.example.app.model.ExampleSystem.Unpredictables.RNG;
 
 import java.awt.Desktop;
+import java.awt.Desktop.Action;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -105,7 +106,7 @@ class IntegrationTest {
 
 			// open the browser
 			URI uri = new URI( "http://localhost:" + service.port() );
-			if( Desktop.isDesktopSupported() ) {
+			if( Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported( Action.BROWSE ) ) {
 				System.out.println( "Opening browser to " + uri );
 				Desktop.getDesktop().browse( uri );
 			}

--- a/message/message-http/pom.xml
+++ b/message/message-http/pom.xml
@@ -24,14 +24,14 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.mastercard.test.flow</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>message-json</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
-			<groupId>com.mastercard.test.flow</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>message-text</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/message/message-web/README.md
+++ b/message/message-web/README.md
@@ -138,7 +138,7 @@ if( assrt.expected().request() instanceof WebSequence
 	response = results.process( driver );
 }
 ```
-[Snippet context](../../example/app-itest/src/test/java/com/mastercard/test/flow/example/app/itest/IntegrationTest.java#L154-L165,154-165)
+[Snippet context](../../example/app-itest/src/test/java/com/mastercard/test/flow/example/app/itest/IntegrationTest.java#L155-L166,155-166)
 
 <!-- snippet end -->
 

--- a/report/report-core/src/main/java/com/mastercard/test/flow/report/Reader.java
+++ b/report/report-core/src/main/java/com/mastercard/test/flow/report/Reader.java
@@ -95,6 +95,16 @@ public class Reader {
 			return Template.extract( file, type );
 		}
 		catch( @SuppressWarnings("unused") FileNotFoundException fnfe ) {
+			if( fnfe.getMessage().contains( "Permission denied" ) ) {
+				// on linux platforms missing read permission results in a
+				// FileNotFoundException.
+				// Our semantics return null if there is no data, so this would be a confusing
+				// debug session: the file is *definitely* there, but Flow is claiming
+				// otherwise by returning null!
+				// Hence we're reduced to looking at the exception message. This is obviously
+				// really fragile, but I don't see a better option
+				throw new IllegalStateException( "Failed to read " + uri, fnfe );
+			}
 			return null;
 		}
 		catch( IOException | UncheckedIOException e ) {

--- a/report/report-core/src/test/java/com/mastercard/test/flow/report/ReaderTest.java
+++ b/report/report-core/src/test/java/com/mastercard/test/flow/report/ReaderTest.java
@@ -18,7 +18,6 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -103,7 +102,7 @@ class ReaderTest {
 	}
 
 	/**
-	 * What happens when we can't read the index /
+	 * What happens when we can't read the index
 	 *
 	 * @throws Exception unexpected oopsy
 	 */
@@ -134,8 +133,6 @@ class ReaderTest {
 	 */
 	@Test
 	@EnabledOnOs(OS.LINUX)
-	@Disabled("TODO: get this working on linux, "
-			+ "becuase harrassing the github build agents is a painful iteration")
 	void badReadLinux() throws Exception {
 		Path dir = Paths.get( "target", "ReaderTest", "badReadLinux" );
 		WriterTest.writeReport( dir );


### PR DESCRIPTION
Resolves #444 : I'm not super-thrilled about this change, but it's an improvement on previous behaviour.

Resolves #455 : I don't quite have the mana to add platform-specific code for something missing from the JRE that should just work by default. I'll settle for no longer throwing an exception.

While we're here, we've:
 * Removed more repetitive `groupId` values
 * Fixed a test failure that'll pop up when we move to a later JRE - we shouldn't really be testing the message of an exception thrown by the JRE
 * Removed an unused import
 * Automated refactor: simplified a while loop