### PR TITLE
Local node install is more ephemeral

### DIFF
--- a/report/report-ng/.gitignore
+++ b/report/report-ng/.gitignore
@@ -44,3 +44,4 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+

--- a/report/report-ng/pom.xml
+++ b/report/report-ng/pom.xml
@@ -143,7 +143,7 @@ Build with
 						<artifactId>frontend-maven-plugin</artifactId>
 						<configuration>
 							<nodeVersion>v14.15.1</nodeVersion>
-							<installDirectory>${user.home}/.node</installDirectory>
+							<installDirectory>target</installDirectory>
 						</configuration>
 						<executions>
 							<execution>
@@ -195,7 +195,7 @@ Build with
 						<artifactId>frontend-maven-plugin</artifactId>
 						<configuration>
 							<nodeVersion>v14.15.1</nodeVersion>
-							<installDirectory>${user.home}/.node</installDirectory>
+							<installDirectory>target</installDirectory>
 						</configuration>
 						<executions>
 							<execution>


### PR DESCRIPTION
The release-build machine seems to have a broken node installation, so let's not use that.