### PR TITLE
Trimming for long-term storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 This branch holds our pages content.
 That used to be a rotating set of build artifacts maintained by [this script](regen_index.pl), but since [#940](https://github.com/Mastercard/flow/pull/940) all we need is:
- * Static links to the latest artifacts (as determined by bowlby)
  * The report content from [#568](https://github.com/Mastercard/flow/pull/568), used as a demo for the report-diffing feature
- * A static set of execution reports. These are updated by [the `state_artifacts` workflow](https://github.com/Mastercard/flow/actions/workflows/static_artifacts.yml) whenever something significant changes in the report. We link to these in our documentation as we don't _entirely_ trust the bowlby instance to always be available.
+ * A static set of execution reports. These are updated by [the `static_artifacts` workflow](https://github.com/Mastercard/flow/actions/workflows/static_artifacts.yml) whenever something significant changes in the report. We link to these in our documentation as we don't _entirely_ trust the bowlby instance to always be available.
 

--- a/index.md
+++ b/index.md
@@ -1,19 +1,16 @@
 # Build artifacts
 
 One of the main features of the [flow testing framework](https://github.com/Mastercard/flow) is the production of rich execution reports.
-Until such a time as [upload-artifact#14](https://github.com/actions/upload-artifact/issues/14) is addressed, we're using the [bowlby](https://github.com/therealryan/bowlby) instance at [https://bowlby.flowty.dev/flow](https://bowlby.flowty.dev/flow) to serve our workflow results.
+Until such a time as [upload-artifact#14](https://github.com/actions/upload-artifact/issues/14) is addressed, we're maintaining a set of static reports for demo purposes here.
 
-See the latest results here:
- * [Testing](https://bowlby.flowty.dev/flow/latest/Mastercard/flow/test.yml)
-   * [Integrated system](https://bowlby.flowty.dev/flow/latest/Mastercard/flow/test.yml/flow_execution_reports/app-itest/target/mctf/latest/index.html)
-   * [Core service](https://bowlby.flowty.dev/flow/latest/Mastercard/flow/test.yml/flow_execution_reports/app-core/target/mctf/latest/index.html)
-   * [Histogram service](https://bowlby.flowty.dev/flow/latest/Mastercard/flow/test.yml/flow_execution_reports/app-histogram/target/mctf/latest/index.html)
-   * [Queue service](https://bowlby.flowty.dev/flow/latest/Mastercard/flow/test.yml/flow_execution_reports/app-queue/target/mctf/latest/index.html)
-   * [Store service](https://bowlby.flowty.dev/flow/latest/Mastercard/flow/test.yml/flow_execution_reports/app-store/target/mctf/latest/index.html)
-   * [UI service](https://bowlby.flowty.dev/flow/latest/Mastercard/flow/test.yml/flow_execution_reports/app-ui/target/mctf/latest/index.html)
-   * [Web UI service](https://bowlby.flowty.dev/flow/latest/Mastercard/flow/test.yml/flow_execution_reports/app-web-ui/target/mctf/latest/index.html)
-   * [Report UI](https://bowlby.flowty.dev/flow/latest/Mastercard/flow/test.yml/angular_coverage/report/index.html)
- * [Mutation](https://bowlby.flowty.dev/flow/latest/Mastercard/flow/mutation.yml/mutation_report/index.html)
+These reports are generated whenever [the `static_artifacts` workflow](https://github.com/Mastercard/flow/actions/workflows/static_artifacts.yml) is run: 
 
-Look at the workflow run summaries for the results of historic runs.
+ * [Integrated system](static/app-itest/target/mctf/latest/index.html)
+ * [Core service](static/app-core/target/mctf/latest/index.html)
+ * [Histogram service](static/app-histogram/target/mctf/latest/index.html)
+ * [Queue service](static/app-queue/target/mctf/latest/index.html)
+ * [Store service](static/app-store/target/mctf/latest/index.html)
+ * [UI service](static/app-ui/target/mctf/latest/index.html)
+ * [Web UI service](static/app-web-ui/target/mctf/latest/index.html)
 
+The same content (along with mutation testing and angular unit testing reports) is available as artifacts from the appropriate workflows.


### PR DESCRIPTION
The counterpart to #967, clearing bowlby links out of our pages branch.